### PR TITLE
Treat inlays=[] and inlays=None differently

### DIFF
--- a/fretboard/fretboard.py
+++ b/fretboard/fretboard.py
@@ -64,7 +64,7 @@ class Fretboard(object):
 
         self.markers = []
 
-        self.inlays = inlays or self.inlays
+        self.inlays = inlays if inlays is not None else self.inlays
 
         self.layout = attrdict.AttrDict()
 


### PR DESCRIPTION
Hi, I needed to make some quick fretboard diagrams the other day and yours was the first I tried. It worked perfectly right of the box, thanks for your work!

I just had one trivial suggestion here, which is to allow `Fretboard(inlays=[])` to specify no inlays, rather than using the default value like `Fretboard(inlays=None)` does



