### PR TITLE
python3 compatibility

### DIFF
--- a/fretboard/utils.py
+++ b/fretboard/utils.py
@@ -13,7 +13,7 @@ def dict_merge(dct, merge_dct):
     """
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)):
+                and isinstance(merge_dct[k], collections.abc.Mapping)):
             dict_merge(dct[k], merge_dct[k])
         else:
             dct[k] = merge_dct[k]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-attrdict==2.0.0
+attrdict3==2.0.0
 svgwrite==1.1.9
 PyYAML==5.1


### PR DESCRIPTION
It looks like attrdict has been replaced by attrdict3, and that collections.Mapping is now collections.abc.Mapping